### PR TITLE
Update Go to 1.25 and dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/Countingup/disintegration-imaging
 
-go 1.22.2
+go 1.25
 
-require golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8
+require golang.org/x/image v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,2 @@
-golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3NCfkPxbDKRdnNE1Rpg0U=
-golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/image v0.36.0 h1:Iknbfm1afbgtwPTmHnS2gTM/6PPZfH+z2EFuOkSbqwc=
+golang.org/x/image v0.36.0/go.mod h1:YsWD2TyyGKiIX1kZlu9QfKIsQ4nAAK9bdgdrIsE7xy4=


### PR DESCRIPTION
Fork of unmaintained module. Update to Go 1.25 and latest golang.org/x/image to resolve security vulns.
